### PR TITLE
reject compressed public keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,6 @@ webpki-roots = "0.26"
 wycheproof = { version = "0.6.0", default-features = false, features = [
     "aead",
     "hkdf",
+    "ecdh",
+    "xdh"
 ] }

--- a/src/kx.rs
+++ b/src/kx.rs
@@ -186,6 +186,7 @@ mod test {
 
     use crate::kx::EcKeyExchange;
 
+    #[cfg(not(feature = "fips"))]
     use super::X25519KeyExchange;
 
     #[rstest::rstest]
@@ -231,6 +232,7 @@ mod test {
         }
     }
 
+    #[cfg(not(feature = "fips"))]
     #[test]
     fn x25519() {
         let test_set = wycheproof::xdh::TestSet::load(wycheproof::xdh::TestName::X25519).unwrap();


### PR DESCRIPTION
add kx whycheproof tests