### PR TITLE
fix: use AES-256-GCM AEAD for TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

### DIFF
--- a/src/tls12.rs
+++ b/src/tls12.rs
@@ -103,7 +103,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: ECDSA_SCHEMES,
-        aead_alg: &aead::Algorithm::Aes128Gcm,
+        aead_alg: &aead::Algorithm::Aes256Gcm,
         prf_provider: &Prf(SHA384),
     });
 


### PR DESCRIPTION
This suite was wired to Aes128Gcm, so a peer negotiating it sealed records with AES-128-GCM instead of AES-256-GCM, surfacing as bad_record_mac.