### PR TITLE
chore: shutdown test server before OpenSSL cleanup starts

### DIFF
--- a/tests/it.rs
+++ b/tests/it.rs
@@ -190,10 +190,11 @@ fn test_client_and_server(
     }
 
     // Run against a server using our default provider
-    let (port, certificate) = start_server(alg, None);
+    let (port, certificate, handle) = start_server(alg, None);
     let provider = custom_provider(vec![suite], vec![group]);
     let actual_suite = test_with_provider(provider, port, vec![certificate]);
     assert_eq!(actual_suite, expected);
+    handle.join().unwrap();
 }
 
 #[cfg(ossl350)]
@@ -209,7 +210,8 @@ fn test_classical_completion() {
         vec![rustls_openssl::kx_group::X25519],
     );
 
-    let (port, certificate) = start_server(server::Alg::PKCS_ECDSA_P256_SHA256, Some(provider));
+    let (port, certificate, handle) =
+        start_server(server::Alg::PKCS_ECDSA_P256_SHA256, Some(provider));
     let provider = custom_provider(
         vec![rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384],
         // specifying both, with the hybrid first, causes rustls to reuse the classical component from the hybrid
@@ -220,6 +222,7 @@ fn test_classical_completion() {
     );
     let actual_suite = test_with_provider(provider, port, vec![certificate]);
     assert_eq!(actual_suite, CipherSuite::TLS13_AES_256_GCM_SHA384);
+    handle.join().unwrap();
 }
 
 #[rstest]
@@ -309,9 +312,10 @@ fn test_to_internet(
 /// Test that the default provider returns the highest priority cipher suite
 #[test]
 fn test_default_client() {
-    let (port, certificate) = start_server(server::Alg::PKCS_RSA_SHA512, None);
+    let (port, certificate, handle) = start_server(server::Alg::PKCS_RSA_SHA512, None);
     let actual_suite = test_with_provider(default_provider(), port, vec![certificate]);
     assert_eq!(actual_suite, CipherSuite::TLS13_AES_256_GCM_SHA384);
+    handle.join().unwrap();
 }
 
 static RSA_SIGNING_SCHEMES: &[SignatureScheme] = &[

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -25,9 +25,14 @@ pub enum Alg {
 /// generating a certificate for `localhost` with the specified algorithm.
 ///
 /// The server will handle a single connection.
+/// Tests must call `join` on the returned thread handle to ensure the server has completed before exiting,
+/// otherwise OpenSSL cleanup may be called while the server thread is still running, which can cause a crash.
 ///
 /// Returns the port the server is listening on and the CA certificate used to sign the server certificate.
-pub fn start_server(alg: Alg, provider: Option<CryptoProvider>) -> (u16, CertificateDer<'static>) {
+pub fn start_server(
+    alg: Alg,
+    provider: Option<CryptoProvider>,
+) -> (u16, CertificateDer<'static>, std::thread::JoinHandle<()>) {
     #[cfg(feature = "fips")]
     {
         rustls_openssl::fips::enable();
@@ -39,34 +44,29 @@ pub fn start_server(alg: Alg, provider: Option<CryptoProvider>) -> (u16, Certifi
 
     let listener = std::net::TcpListener::bind("[::]:0").unwrap();
     let port = listener.local_addr().unwrap().port();
-    std::thread::spawn(move || {
+    let handle = std::thread::spawn(move || {
         let mut stream = listener.incoming().next().unwrap().unwrap();
         let mut acceptor = Acceptor::default();
 
-        loop {
-            acceptor.read_tls(&mut stream).unwrap();
-            if let Some(accepted) = acceptor.accept().unwrap() {
-                let mut conn = accepted.into_connection(server_config.clone()).unwrap();
-                let msg = concat!(
-                    "HTTP/1.1 200 OK\r\n",
-                    "Connection: Closed\r\n",
-                    "Content-Type: text/html\r\n",
-                    "\r\n",
-                    "<h1>Hello World!</h1>\r\n"
-                )
-                .as_bytes();
+        acceptor.read_tls(&mut stream).unwrap();
+        if let Some(accepted) = acceptor.accept().unwrap() {
+            let mut conn = accepted.into_connection(server_config.clone()).unwrap();
+            let msg = concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Connection: Closed\r\n",
+                "Content-Type: text/html\r\n",
+                "\r\n",
+                "<h1>Hello World!</h1>\r\n"
+            )
+            .as_bytes();
 
-                conn.writer().write_all(msg).unwrap();
-                conn.write_tls(&mut stream).unwrap();
-                conn.complete_io(&mut stream).unwrap();
-
-                conn.send_close_notify();
-                conn.write_tls(&mut stream).unwrap();
-                conn.complete_io(&mut stream).unwrap();
-            }
+            conn.writer().write_all(msg).unwrap();
+            conn.send_close_notify();
+            conn.write_tls(&mut stream).unwrap();
+            conn.complete_io(&mut stream).unwrap();
         }
     });
-    (port, ca_cert_der)
+    (port, ca_cert_der, handle)
 }
 
 struct TestPki {


### PR DESCRIPTION
there's been a bunch of CI test failures recently caused by OpenSSL cleanup starting before the server thread is shutdown